### PR TITLE
changed environment.yml to reflect conda environment name in README.md

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: explorer
+name: explore_australia
 
 dependencies:
   - python=3.6


### PR DESCRIPTION
In the readme.md, under installation, instructions are given to activate the conda envioronment by executing "conda activate explore_australia" after using the environment.yml included in the repository.

The conda environment name in the environment.yml was "explorer", so this command isn't going to work.  I changed the environment.yml environment name to "explore_australia", so the instructions in the readme.md will work.